### PR TITLE
Added member_name to removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ venv.bak/
 
 # Local database
 LPD_database*.csv
+*.sqlite

--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -58,7 +58,7 @@ class Officer:
     async def remove(self):
 
         # Remove itself
-        display_name = await self.bot.get_guild(self.bot.settings["Server_ID"]).get_member(self.id).display_name
+        display_name = self.member.display_name
         await self.bot.officer_manager.remove_officer(self.id, display_name=display_name)
 
     # ====================

--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -58,7 +58,8 @@ class Officer:
     async def remove(self):
 
         # Remove itself
-        await self.bot.officer_manager.remove_officer(self.id)
+        display_name = await self.bot.get_guild(self.bot.settings["Server_ID"]).get_member(self.id).display_name
+        await self.bot.officer_manager.remove_officer(self.id, display_name=display_name)
 
     # ====================
     # properties

--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -154,7 +154,7 @@ class Officer:
             + str(math.floor(end_time - start_time))
         )
 
-        await self.bot.officer_manager.send_db_request(
+        await self.bot.sql.request(
             "INSERT INTO TimeLog(officer_id, start_time, end_time) VALUES (%s, %s, %s)",
             (self.id, string_start_time, string_end_time),
         )
@@ -167,7 +167,7 @@ class Officer:
         to_db_time = to_datetime_object.strftime(self.bot.settings["db_time_format"])
 
         # Execute the query to get the time information
-        result = await self.bot.officer_manager.send_db_request(
+        result = await self.bot.sql.request(
             """
             SELECT SUM(TIMESTAMPDIFF(SECOND, start_time, end_time)) AS 'Time'
             FROM TimeLog
@@ -187,7 +187,7 @@ class Officer:
     async def get_full_time(self, from_datetime_object, to_datetime_object):
 
         # Execute the query to get the time information
-        result = await self.bot.officer_manager.send_db_request(
+        result = await self.bot.sql.request(
             """
             SELECT start_time, end_time, TIMESTAMPDIFF(SECOND, start_time, end_time) AS 'duration'
             FROM TimeLog
@@ -245,7 +245,7 @@ class Officer:
         )
 
         # Get the row ID for the last activity in the channel
-        row_id = await self.bot.officer_manager.send_db_request(
+        row_id = await self.bot.sql.request(
             "SELECT entry_number FROM MessageActivityLog WHERE officer_id = %s AND channel_id = %s",
             (self.id, msg.channel.id),
         )
@@ -253,12 +253,12 @@ class Officer:
         # Insert the data into the database
         if row_id:
             row_id = row_id[0][0]
-            await self.bot.officer_manager.send_db_request(
+            await self.bot.sql.request(
                 "UPDATE MessageActivityLog SET message_id = %s, send_time = %s WHERE entry_number = %s",
                 (msg.id, string_send_time, row_id),
             )
         else:
-            await self.bot.officer_manager.send_db_request(
+            await self.bot.sql.request(
                 "INSERT INTO MessageActivityLog(message_id, channel_id, officer_id, send_time) VALUES (%s, %s, %s, %s)",
                 (msg.id, msg.channel.id, self.id, string_send_time),
             )
@@ -279,7 +279,7 @@ class Officer:
         #     1) The messages from MessageActivityLog        - other_activity is null
         #     2) Last on duty activity                       - other_activity is On duty activity
         #     3) When the bot started monitoring the officer - other_activity is Started monitoring
-        result = await self.bot.officer_manager.send_db_request(
+        result = await self.bot.sql.request(
             """
             SELECT officer_id, channel_id, message_id, send_time, null AS "other_activity"
             FROM MessageActivityLog

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -244,6 +244,15 @@ class OfficerManager:
                 traceback.format_exc(),
             )
 
+        # Get display name for the Officer to be removed
+        member = self.guild.get_member(officer_id)
+        
+        if member == None:
+            member_name = ''
+        else:
+            member_name = member.display_name + ' '
+        
+        
         await self.send_db_request(
             "DELETE FROM MessageActivityLog WHERE officer_id = %s", (officer_id)
         )
@@ -264,6 +273,7 @@ class OfficerManager:
 
         msg_string = (
             "WARNING: "
+            + member_name
             + str(officer_id)
             + " has been removed from the LPD Officer Monitor"
         )

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -246,9 +246,9 @@ class OfficerManager:
 
         # Get display name for the Officer to be removed
         if display_name == None:
-            member_name = ''
+            member_name = str(officer_id)
         else:
-            member_name = display_name + ' '
+            member_name = display_name + '(' + str(officer_id) + ')'
         
         
         await self.send_db_request(
@@ -272,7 +272,6 @@ class OfficerManager:
         msg_string = (
             "WARNING: "
             + member_name
-            + '(' + str(officer_id) + ')'
             + " has been removed from the LPD Officer Monitor"
         )
         if reason is not None:

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -248,7 +248,7 @@ class OfficerManager:
         if display_name == None:
             member_name = str(officer_id)
         else:
-            member_name = display_name + '(' + str(officer_id) + ')'
+            member_name = display_name + ' (' + str(officer_id) + ')'
         
         
         await self.send_db_request(

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -248,7 +248,7 @@ class OfficerManager:
         if display_name == None:
             member_name = str(officer_id)
         else:
-            member_name = display_name + ' (' + str(officer_id) + ')'
+            member_name = f'{display_name} ({officer_id})'
         
         
         await self.send_db_request(

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -272,7 +272,7 @@ class OfficerManager:
         msg_string = (
             "WARNING: "
             + member_name
-            + str(officer_id)
+            + '(' + str(officer_id) + ')'
             + " has been removed from the LPD Officer Monitor"
         )
         if reason is not None:

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -231,7 +231,7 @@ class OfficerManager:
         # Return the officer
         return new_officer
 
-    async def remove_officer(self, officer_id, reason=None):
+    async def remove_officer(self, officer_id, reason=None, display_name=None):
 
         # Run the function that needs to run before the officer removal
         try:
@@ -245,12 +245,10 @@ class OfficerManager:
             )
 
         # Get display name for the Officer to be removed
-        member = self.guild.get_member(officer_id)
-        
-        if member == None:
+        if display_name == None:
             member_name = ''
         else:
-            member_name = member.display_name + ' '
+            member_name = display_name + ' '
         
         
         await self.send_db_request(

--- a/Classes/VRChatUserManager.py
+++ b/Classes/VRChatUserManager.py
@@ -76,7 +76,7 @@ class VRChatUserManager:
         self.all_users.append([discord_id, vrchat_name])
 
         # Add to the permanent DB
-        await self.bot.officer_manager.send_db_request(
+        await self.bot.sql.request(
             """
             INSERT INTO 
                 VRChatNames(officer_id, vrc_name)
@@ -92,12 +92,12 @@ class VRChatUserManager:
         self.all_users = [x for x in self.all_users if x[0] != discord_id]
 
         # Remove from the permanent DB
-        await self.bot.officer_manager.send_db_request(
+        await self.bot.sql.request(
             "DELETE FROM VRChatNames WHERE officer_id = %s", (discord_id)
         )
 
     async def update_cache(self):
-        db_result = await self.bot.officer_manager.send_db_request(
+        db_result = await self.bot.sql.request(
             "SELECT officer_id, vrc_name FROM VRChatNames", ()
         )
 

--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ async def on_member_update(before, after):
 async def on_member_remove(member):
     if bot.officer_manager.is_officer(member):
         await bot.officer_manager.remove_officer(
-            member.id, reason="this person left the server."
+            member.id, reason="this person left the server.", display_name=member.display_name
         )
 
 

--- a/main.py
+++ b/main.py
@@ -217,7 +217,7 @@ async def on_member_update(before, after):
     # Member has left the LPD
     elif officer_before is True and officer_after is False:
         await bot.officer_manager.remove_officer(
-            before.id, reason="this person does not have the LPD role anymore"
+            before.id, reason="this person does not have the LPD role anymore", display_name=after.display_name
         )
 
 

--- a/version.json
+++ b/version.json
@@ -1,10 +1,11 @@
 [
   {
-    "version": "2.0",
+    "version": "2.0.4",
     "developer": "hrolfurgylfa",
     "contributors": [
       "CaptainDestructo",
       "50thomatoes50"
-    ]
+    ],
+    "update_description": "Adds member's display name to the removal message in the debug log"
   }
 ]

--- a/version.json
+++ b/version.json
@@ -1,0 +1,10 @@
+[
+  {
+    "version": "2.0",
+    "developer": "hrolfurgylfa",
+    "contributors": [
+      "CaptainDestructo",
+      "50thomatoes50"
+    ]
+  }
+]


### PR DESCRIPTION
When a user is removed from the Officer Monitor, their display name is not shown like it is when they're added. This code displays it unless the user has left the server, in which case the name cannot be fetched.