### PR TITLE
Destructo timezone patch

### DIFF
--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -109,9 +109,16 @@ class Officer:
                 "NOV": 11,
                 "DEC": 12,
             }
+
+            # Ensure day is numeric
             int(date_start[0])
             int(date_end[0])
 
+            # Ensure year is numeric
+            int(date_start[2])
+            int(date_end[2])
+
+            # Get month number from dictionary
             date_start[1] = date_start[1].upper()[0:3]
             date_start[1] = months[date_start[1]]
             date_end[1] = date_end[1].upper()[0:3]

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -54,11 +54,16 @@ class OfficerManager:
                 print(
                     f"Added {new_officer.member.name}#{new_officer.member.discriminator} to the Officer Manager."
                 )
-                
+
                 # Check to see if the officer is in an on duty VC, and if so, put them on duty, put a message in stdout and increment a counter
                 if new_officer.member.voice is not None:
-                    if new_officer.member.voice.channel.category_id == self.bot.settings["on_duty_category"]:
-                        print(f'Note: {new_officer.member.name}#{new_officer.member.discriminator} is on duty. Starting their time now...')
+                    if (
+                        new_officer.member.voice.channel.category_id
+                        == self.bot.settings["on_duty_category"]
+                    ):
+                        print(
+                            f"Note: {new_officer.member.name}#{new_officer.member.discriminator} is on duty. Starting their time now..."
+                        )
                         new_officer.go_on_duty()
                         self._number_officers_on_duty_at_launch += 1
 
@@ -69,17 +74,19 @@ class OfficerManager:
                 self._officers_needing_removal.append(officer_id)
 
         print(f"Officers needing removal: {self._officers_needing_removal}")
-        
+
         # If there were officers on duty when the OfficerManager started, put a warning in stdout
         if self._number_officers_on_duty_at_launch > 1:
-            pretty_text = f'were {self._number_officers_on_duty_at_launch} officers'
+            pretty_text = f"were {self._number_officers_on_duty_at_launch} officers"
 
         if self._number_officers_on_duty_at_launch == 1:
-            pretty_text = f'was {self._number_officers_on_duty_at_launch} officer'
+            pretty_text = f"was {self._number_officers_on_duty_at_launch} officer"
 
         if self._number_officers_on_duty_at_launch > 0:
-            print(f'WARNING: It looks like there {pretty_text} on duty when the Officer Manager was started... This is indicative of a bot crash. Any on-duty time not logged before the bot crashed will not be logged. Their time has been restarted.')
-        
+            print(
+                f"WARNING: It looks like there {pretty_text} on duty when the Officer Manager was started... This is indicative of a bot crash. Any on-duty time not logged before the bot crashed will not be logged. Their time has been restarted."
+            )
+
         # Set up the automatically running code
         bot.loop.create_task(self.loop())
 
@@ -176,7 +183,7 @@ class OfficerManager:
             try:
                 await self.bot.sql.request(
                     "INSERT INTO Officers(officer_id, started_monitoring_time) Values (%s, %s)",
-                    (officer_id, datetime.now(timezone.utc)),
+                    (officer_id, datetime.utcnow()),
                 )
             except mysql_errors.IntegrityError as error:
                 print(repr(error.args))
@@ -231,8 +238,8 @@ class OfficerManager:
         if display_name == None:
             member_name = str(officer_id)
         else:
-            member_name = f'{display_name} ({officer_id})'
-        
+            member_name = f"{display_name} ({officer_id})"
+
         await self.bot.sql.request(
             "DELETE FROM MessageActivityLog WHERE officer_id = %s", (officer_id)
         )
@@ -252,9 +259,7 @@ class OfficerManager:
                 i += 1
 
         msg_string = (
-            "WARNING: "
-            + member_name
-            + " has been removed from the LPD Officer Monitor"
+            "WARNING: " + member_name + " has been removed from the LPD Officer Monitor"
         )
         if reason is not None:
             msg_string += " because " + str(reason)

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -231,7 +231,7 @@ class Time(commands.Cog):
                 # The user is giving from_time and thus wants from_time
                 # to be the current time
                 from_datetime = self.parse_date(parsed.from_date)
-                to_datetime = datetime.now(timezone.utc)
+                to_datetime = datetime.utcnow()
 
             else:
                 # Both are here, they can just be parsed
@@ -509,8 +509,8 @@ class Time(commands.Cog):
 
         # Get everyone that has been active enough
         all_times = await self.bot.officer_manager.get_most_active_officers(
-            datetime.now(timezone.utc) - timedelta(days=28),
-            datetime.now(timezone.utc),
+            datetime.utcnow() - timedelta(days=28),
+            datetime.utcnow(),
             limit=None,
         )
 
@@ -645,7 +645,7 @@ class Time(commands.Cog):
             last_activity = await officer.get_last_activity(
                 ctx.bot.officer_manager.all_monitored_channels
             )
-            active_days_ago = (datetime.now(timezone.utc) - last_activity["time"]).days
+            active_days_ago = (datetime.utcnow() - last_activity["time"]).days
             if active_days_ago > inactive_days_required:
                 officers_to_remove.append(officer)
 

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import argparse
 import re
 from io import StringIO, BytesIO
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import time
 import math
 import traceback
@@ -722,7 +722,7 @@ class Time(commands.Cog):
                     last_active_time = 0
 
                 # Get the patrol time
-                to_time = datetime.now(tz=timezone.utc)
+                to_time = datetime.utcnow()
                 from_time = to_time - timedelta(28)
                 patrol_time = await officer.get_time(from_time, to_time)
 


### PR DESCRIPTION
Changed all occurrences of datetime.now(timezone.utc) to datetime.utcnow(). Also patched the LOA year validation

This *should* work. Don't have time to test it right now.