### PR TITLE
Added rejection for no VRChat name specified in =link

### DIFF
--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -904,8 +904,15 @@ class VRChatAccoutLink(commands.Cog):
         debug console can be enabled with a button under the front desk.
         """
 
+        if not args:
+            await ctx.channel.send("Please specify your VRChat name.")
+            return
+        
         # Check if -s is specified
         if args[0] == "-s":
+            if len(args) == 1:
+                await ctx.channel.send("Please specify your VRChat name.")
+                return
             skip_formatting = True
         else:
             skip_formatting = False


### PR DESCRIPTION
Added error handling if somebody runs `=link` without specifying their name.