### PR TITLE
Removed all references to `send_db_request`

### DIFF
--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -194,7 +194,7 @@ class Officer:
 
         # Fire the script to save the entry
         request_id = message.id
-        old_messages = await self.bot.officer_manager.send_db_request(
+        old_messages = await self.bot.sql.request(
             "SELECT request_id FROM LeaveTimes WHERE officer_id = %s", self.id
         )
 
@@ -217,12 +217,12 @@ class Officer:
         """
 
         # Delete any existing entries
-        await self.bot.officer_manager.send_db_request(
+        await self.bot.sql.request(
             "DELETE FROM LeaveTimes WHERE officer_id = %s", self.id
         )
 
         # Save the new entry
-        await self.bot.officer_manager.send_db_request(
+        await self.bot.sql.request(
             "REPLACE INTO `LeaveTimes` (`officer_id`,`date_start`,`date_end`,`reason`,`request_id`) VALUES (%s, %s, %s, %s, %s)",
             (self.id, date_start, date_end, reason, request_id),
         )

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -99,10 +99,6 @@ class OfficerManager:
             run_before_officer_removal=run_before_officer_removal,
         )
 
-    async def send_db_request(self, query, args=None):
-        """This function is being deprecated in favor of self.bot.sql.request()"""
-        return await self.bot.sql.request(query, args)
-
     # =====================
     #    Loop
     # =====================
@@ -326,12 +322,12 @@ class OfficerManager:
         Delete the specified Leave of Absence
         """
 
-        await self.send_db_request(
+        await self.bot.sql.request(
             "DELETE FROM LeaveTimes WHERE request_id = %s", (request_id)
         )
 
     async def get_loa(self):
-        loa_entries = await self.send_db_request(
+        loa_entries = await self.bot.sql.request(
             "SELECT officer_id, date(date_start), date(date_end), reason, request_id FROM LeaveTimes"
         )
 


### PR DESCRIPTION
As `bot.officer_manager.send_db_request` has been deprecated in favor of `bot.sql.request` and phased out, it is fitting to remove all references to it and to remove the adapter function which points it to `bot.sql.request`.