### PR TITLE
Voice is NoneType error patch

### DIFF
--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -39,18 +39,19 @@ class Officer:
             )
             return
 
-        print(
-            f"{self.discord_name} is going on duty in {self.member.voice.channel.name}"
-        )
         # Start counting the officers time
         self._on_duty_start_time = time.time()
         self.is_on_duty = True
+
+        print(
+            f"{self.discord_name} is going on duty in {self.member.voice.channel.name}"
+        )
         self.squad = self.member.voice.channel
 
     def update_squad(self):
 
         # Print an error if the user is going on duty even though he is already on duty
-        if self.is_on_duty is False:
+        if not self.is_on_duty:
             print("WARNING: Tried to update squad for a user not on duty...")
             return
 

--- a/Classes/extra_functions.py
+++ b/Classes/extra_functions.py
@@ -148,7 +148,7 @@ async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt"
         print("Stopping the bot without stopping time...")
 
     # Log the shutdown
-    msg_string = f"WARNING: Bot shut down from {location} by {person}"
+    msg_string = f"WARNING: Bot {'shut down' if exit else 'restarted'} from {location} by {person}"
     channel = bot.get_channel(bot.settings["error_log_channel"])
     await channel.send(msg_string)
     print(msg_string)

--- a/Classes/extra_functions.py
+++ b/Classes/extra_functions.py
@@ -131,7 +131,7 @@ async def send_str_as_file(
         )
 
 
-async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt"):
+async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt", exit=True):
     """Cleanly shutdown the bot"""
 
     # Put all on-duty officers off duty - don't worry,
@@ -153,11 +153,12 @@ async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt"
     await channel.send(msg_string)
     print(msg_string)
 
-    # Stop the event loop and exit Python. The OS should be
-    # calling this script inside a loop if you want the bot to restart
-    loop = asyncio.get_event_loop()
-    loop.stop()
-    exit(0)
+    if exit:
+        # Stop the event loop and exit Python. The OS should be
+        # calling this script inside a loop if you want the bot to restart
+        loop = asyncio.get_event_loop()
+        loop.stop()
+        exit(0)
 
 
 async def analyze_promotion_request(bot, message, timeout_in_seconds=300):

--- a/Classes/extra_functions.py
+++ b/Classes/extra_functions.py
@@ -1,7 +1,7 @@
 # Standard
 from typing import Optional
 import discord
-from os import _exit as exit
+from os import _exit
 import asyncio
 from io import StringIO, BytesIO
 
@@ -158,7 +158,7 @@ async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt"
         # calling this script inside a loop if you want the bot to restart
         loop = asyncio.get_event_loop()
         loop.stop()
-        exit(0)
+        _exit(0)
 
 
 async def analyze_promotion_request(bot, message, timeout_in_seconds=300):

--- a/main.py
+++ b/main.py
@@ -111,13 +111,8 @@ async def on_ready():
     global bot
 
     # Make sure this function does not create the officer manager twice
-    if bot.officer_manager is not None:
-        await clean_shutdown(location="disconnection", person="automatic recovery", exit=False)
-        return
-
-    if bot.sql is not None:
-        await clean_shutdown(location="disconnection", person="automatic recovery", exit=False)
-        return
+    if bot.officer_manager is not None or bot.sql is not None:
+        await clean_shutdown(bot, location="disconnection", person="automatic recovery", exit=False)
 
     # Create the function to run before officer removal
     async def before_officer_removal(bot, officer_id):

--- a/main.py
+++ b/main.py
@@ -112,9 +112,11 @@ async def on_ready():
 
     # Make sure this function does not create the officer manager twice
     if bot.officer_manager is not None:
+        await clean_shutdown(location="disconnection", person="automatic recovery", exit=False)
         return
 
     if bot.sql is not None:
+        await clean_shutdown(location="disconnection", person="automatic recovery", exit=False)
         return
 
     # Create the function to run before officer removal

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ async def on_ready():
     global bot
 
     # Make sure this function does not create the officer manager twice
-    if bot.officer_manager is not None or bot.sql is not None:
+    if bot.sql is not None:
         await clean_shutdown(bot, location="disconnection", person="automatic recovery", exit=False)
 
     # Create the function to run before officer removal


### PR DESCRIPTION
This pull request fixes the linked issue.

When `on_ready` is called, the bot will call `clean_shutdown` with a newly added `exit=False` argument to avoid killing the python interpreter, and will then reinstantiate SQL Manager, Officer Manager, and User Manager. This causes all of the `Officer` objects to become reloaded, along with their appropriate `discord.Member` objects as properties. This eliminates the bug when @hrolfurgylfa 's internet dies.