### PR TITLE
Inactive system adjustments

### DIFF
--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -6,6 +6,7 @@
 import asyncio
 import traceback
 from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
 
 # Community
 import aiomysql
@@ -264,8 +265,18 @@ class OfficerManager:
     #    check officers
     # ====================
 
-    async def get_most_active_officers(self, from_datetime, to_datetime, limit=None):
-        """Returns list of most active officers between given dates, up to optionally specified limit"""
+    async def get_most_active_officers(
+        self,
+        from_datetime: datetime,
+        to_datetime: datetime,
+        limit: Optional[int] = None,
+    ):
+        """
+        Returns list of most active officers between given dates, up to optionally specified limit.
+
+        This can both be used when the most active officers are needed or if you need to get all
+        officers and how active they have been over a specific amount of time.
+        """
 
         db_request = """
             SELECT officer_id, SUM(TIMESTAMPDIFF(SECOND, start_time, end_time)) AS "patrol_length"
@@ -274,7 +285,7 @@ class OfficerManager:
             GROUP BY officer_id
             ORDER BY patrol_length DESC
             """
-        arg_list = [from_datetime, to_datetime]
+        arg_list: List[Any] = [from_datetime, to_datetime]
 
         if limit:
             db_request += "\nLIMIT %s"

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -6,7 +6,7 @@
 import asyncio
 import traceback
 from datetime import datetime, timezone
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Community
 import aiomysql
@@ -301,6 +301,16 @@ class OfficerManager:
             arg_list.append(limit)
 
         return await self.bot.sql.request(db_request, arg_list)
+
+    async def get_officer_renew_dates(self) -> Dict[int, datetime]:
+        """
+        Returns a dictionary with the officer id as key, and then when their time was last
+        renewed or join date as the value, witch ever one is higher.
+        """
+        data = await self.bot.sql.request(
+            "SELECT officer_id, renewed_time, started_monitoring_time FROM Officers"
+        )
+        return dict(zip(data[0], max(data[1], data[2])))
 
     def is_officer(self, member):
         """Returns true if specified member object has and of the LPD roles"""

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -310,7 +310,7 @@ class OfficerManager:
         data = await self.bot.sql.request(
             "SELECT officer_id, renewed_time, started_monitoring_time FROM Officers"
         )
-        return dict(zip(data[0], max(data[1], data[2])))
+        return {d[0]: max(d[1], d[2]) for d in data}
 
     def is_officer(self, member):
         """Returns true if specified member object has and of the LPD roles"""

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -861,7 +861,7 @@ class Inactivity(commands.Cog):
             await ctx.send("No one was skipped because of chat activity.")
         else:
             skipped_str = (
-                "The following were skipped because of recent chat activity or being new:\n"
+                "The following were skipped because of recent chat activity, on duty activity or being new:\n"
                 + "\n".join(m.mention for m in skipped_officers)
             )
             await send_long(ctx.channel, skipped_str, mention=False)

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -815,7 +815,7 @@ class Inactivity(commands.Cog):
             self.bot.settings["inactive_role"]
         )
 
-        # Output the list of officers and get confirmation
+        # Output the list of officers and get confirmation to mark them as inactive
         output_string = ""
         for officer in inactive_officers:
             output_string = f"{officer.mention}\n{output_string}"

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -838,11 +838,21 @@ class Inactivity(commands.Cog):
                 f"Do you want to mark the officers above as inactive?"
             ).prompt(ctx)
             if confirm:
+                # Add the inactive roles
+                await ctx.send("Please give me a moment to add the roles.")
                 for officer in inactive_officers:
                     await officer.member.add_roles(role)
                 await ctx.channel.send(
                     f"All officers above have been marked as inactive."
                 )
+
+                # Notify about who was skipped because of chat activity
+                skipped_str = (
+                    "The following were skipped because of recent chat activity or being new:\n"
+                    + "\n".join(m.mention for m in chat_activity_skipped)
+                )
+                await send_long(ctx.channel, skipped_str, mention=False)
+
             else:
                 await ctx.channel.send("Cancelled.")
 

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -758,6 +758,8 @@ class Inactivity(commands.Cog):
         # Get all fields from LeaveTimes
         loa_entries = await self.bot.officer_manager.get_loa()
 
+        # TODO: Count having a message in #leave-of-absence as having a LOA
+
         # If the entry is still good, add the officer to our exclusion list. Otherwise, delete the entry if expired.
         loa_officer_ids = {entry[0] for entry in loa_entries}
 
@@ -780,6 +782,7 @@ class Inactivity(commands.Cog):
         not_enough_patrol: List[Officer] = []
         for officer_id, active_seconds in officer_activity:
             active_seconds = active_seconds or 0
+            # TODO: Count last_joined activity as on duty (allow two months of inactivity after joining)
             if officer_id not in loa_officer_ids and active_seconds < min_activity * 60:
                 officer = self.bot.officer_manager.get_officer(officer_id)
                 not_enough_patrol.append(officer)

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -951,9 +951,9 @@ class Inactivity(commands.Cog):
             string = "There are no Leaves of Absence on file at this time."
 
         else:
+            string = f"There are currently Leaves of Absence on file for the following Officers:"
             for entry in loa_entries:
                 officer = self.bot.get_user(entry[0])
-                string = f"There are currently Leaves of Absence on file for the following Officers:"
                 string = f"{string}\n{officer.mention} from {entry[1]} to {entry[2]} for reason: {entry[3]}"
                 if len(string) > 1000:
                     await ctx.channel.send(string)

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -755,13 +755,17 @@ class Inactivity(commands.Cog):
         Use the `-i` flag to mark officers inactive individually.
         """
 
-        # Get all fields from LeaveTimes
+        # Get the LOA Officers from the database
         loa_entries = await self.bot.officer_manager.get_loa()
-
-        # TODO: Count having a message in #leave-of-absence as having a LOA
-
-        # If the entry is still good, add the officer to our exclusion list. Otherwise, delete the entry if expired.
         loa_officer_ids = {entry[0] for entry in loa_entries}
+
+        # Count having a message in #leave-of-absence as having a LOA
+        # This is really slow and should be removed when we're sure all LOA's are in the database
+        loa_channel = self.bot.officer_manager.guild.get_channel(
+            self.bot.settings["leave_of_absence_channel"]
+        )
+        async for old_message in loa_channel.history(limit=None):
+            loa_officer_ids.add(old_message.author.id)
 
         # For everyone in the server where their role is in the role ladder,
         # get their last activity times, or if no last activity time, use

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -757,11 +757,8 @@ class Inactivity(commands.Cog):
         # Get all fields from LeaveTimes
         loa_entries = await self.bot.officer_manager.get_loa()
 
-        loa_officer_ids = []
-
         # If the entry is still good, add the officer to our exclusion list. Otherwise, delete the entry if expired.
-        for entry in loa_entries:
-            loa_officer_ids.append(entry[0])
+        loa_officer_ids = {entry[0] for entry in loa_entries}
 
         # For everyone in the server where their role is in the role ladder,
         # get their last activity times, or if no last activity time, use

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -897,8 +897,26 @@ class Inactivity(commands.Cog):
     @commands.command()
     async def mark_inactive(self, ctx):
         """
-        This command lists inactive officers, and prompts the user to mark them with the LPD_inactive role.
-        Use the `-i` flag to mark officers inactive individually.
+        This command lists inactive officers, and prompts the user to mark them with the
+        LPD_inactive role.
+
+        **Explanation of command logic:**
+        Anything within quotes ("") is a number that can change based on the bots settings, consult
+        a bot developer if you want to know the specifics of what a variable is set to.
+
+        To be marked as inactive you must fill all of the below requirements:
+        * Not have patrolled "min_activity_minutes" minutes within the last "max_inactive_days" days
+        * Not have joined the LPD or had your time renewed within that time
+        * Not have an active LOA
+        * Not be a white shirt (they're handled in a different way)
+        * Not be skipped because of chat activity (explained below)
+
+        To be skipped because of chat activity you can fill either of the requirements below:
+        * Have a message in a monitored channel in the last "max_inactive_msg_days" days.
+        * Have gone on duty in that time
+
+        Being skipped because of chat activity means that that person will not be marked as inactive
+        automatically, however, will go onto a list that is displayed after this command completes.
         """
 
         # Get the inactive officers

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -748,7 +748,6 @@ class Inactivity(commands.Cog):
     @checks.is_admin_bot_channel()
     @checks.is_white_shirt()
     @commands.command()
-    # Mark Officers inactive after running =list_inactive
     async def mark_inactive(self, ctx):
         """
         This command lists inactive officers, and prompts the user to mark them with the LPD_inactive role.

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -815,46 +815,30 @@ class Inactivity(commands.Cog):
             self.bot.settings["inactive_role"]
         )
 
-        if "-i" in ctx.message.content:
+        # Output the list of officers and get confirmation
+        output_string = ""
+        for officer in inactive_officers:
+            output_string = f"{officer.mention}\n{output_string}"
+        await send_long(ctx.channel, output_string, mention=False)
+        confirm = await Confirm(
+            f"Do you want to mark the officers above as inactive?"
+        ).prompt(ctx)
+        if confirm:
+            # Add the inactive roles
+            await ctx.send("Please give me a moment to add the roles.")
             for officer in inactive_officers:
-                confirm = await Confirm(
-                    f"Do you want to mark {officer.mention} as inactive?"
-                ).prompt(ctx)
-                if confirm:
-                    await officer.member.add_roles(role)
-                    await ctx.channel.send(
-                        f"{officer.mention} has been marked as inactive."
-                    )
-                else:
-                    await ctx.channel.send(
-                        f"{officer.mention} will have their inactivity reevaluated at a later date."
-                    )
+                await officer.member.add_roles(role)
+            await ctx.channel.send(f"All officers above have been marked as inactive.")
+
+            # Notify about who was skipped because of chat activity
+            skipped_str = (
+                "The following were skipped because of recent chat activity or being new:\n"
+                + "\n".join(m.mention for m in chat_activity_skipped)
+            )
+            await send_long(ctx.channel, skipped_str, mention=False)
+
         else:
-            output_string = ""
-            for officer in inactive_officers:
-                output_string = f"{officer.mention}\n{output_string}"
-            await send_long(ctx.channel, output_string, mention=False)
-            confirm = await Confirm(
-                f"Do you want to mark the officers above as inactive?"
-            ).prompt(ctx)
-            if confirm:
-                # Add the inactive roles
-                await ctx.send("Please give me a moment to add the roles.")
-                for officer in inactive_officers:
-                    await officer.member.add_roles(role)
-                await ctx.channel.send(
-                    f"All officers above have been marked as inactive."
-                )
-
-                # Notify about who was skipped because of chat activity
-                skipped_str = (
-                    "The following were skipped because of recent chat activity or being new:\n"
-                    + "\n".join(m.mention for m in chat_activity_skipped)
-                )
-                await send_long(ctx.channel, skipped_str, mention=False)
-
-            else:
-                await ctx.channel.send("Cancelled.")
+            await ctx.channel.send("Cancelled.")
 
     @checks.is_admin_bot_channel()
     @checks.is_white_shirt()

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -769,9 +769,8 @@ class Inactivity(commands.Cog):
         max_inactive_days = self.bot.settings["max_inactive_days"]
         oldest_valid = datetime.utcnow() - timedelta(days=max_inactive_days)
         inactive_officers = []
-        role_ids = role_id_index(self.bot.settings)
 
-        for id, officer in self.bot.officer_manager.all_officers.items():
+        for officer in self.bot.officer_manager.all_officers.values():
             if officer.id not in loa_officer_ids:
                 last_activity = await officer.get_last_activity(
                     self.bot.officer_manager.all_monitored_channels

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -791,6 +791,11 @@ class Inactivity(commands.Cog):
             if officer_id in last_renew and last_renew[officer_id] > min_activity * 60:
                 continue
 
+            # Skip White Shirts, they're handled in a different way
+            officer: Officer = self.bot.officer_manager.get_officer(officer_id)
+            if officer and officer.is_white_shirt:
+                continue
+
             # Skip LOA officers
             if officer_id in loa_officer_ids:
                 continue

--- a/Classes/extra_functions.py
+++ b/Classes/extra_functions.py
@@ -17,8 +17,13 @@ def is_number(string):
         return False
 
 
-async def send_long(channel, string, code_block=False):
+async def send_long(channel, string, code_block=False, mention=True):
     """Send output as a text file, or optionally a code block if code_block=True is passed"""
+
+    # Set allowed mentions
+    allowed_mentions = (
+        discord.AllowedMentions.all() if mention else discord.AllowedMentions.none()
+    )
 
     # Make a function to check the length of all the lines
     str_list_len = lambda str_list: sum(len(i) + 1 for i in str_list)
@@ -56,11 +61,14 @@ async def send_long(channel, string, code_block=False):
             output_list.append(line)
         else:
             # Send the full message and add backticks if needed
-            await channel.send("\n".join(output_list) + ("```" if code_block else ""))
+            await channel.send(
+                "\n".join(output_list) + ("```" if code_block else ""),
+                allowed_mentions=allowed_mentions,
+            )
             # Add the backticks if the message should be in a codeblock
             output_list = [("```" if code_block else "") + line]
 
-    await channel.send("\n".join(output_list))
+    await channel.send("\n".join(output_list), allowed_mentions=allowed_mentions)
 
 
 def get_settings_file(settings_file_name, in_settings_folder=True):
@@ -131,7 +139,9 @@ async def send_str_as_file(
         )
 
 
-async def clean_shutdown(bot, location="the console", person="KeyboardInterrupt", exit=True):
+async def clean_shutdown(
+    bot, location="the console", person="KeyboardInterrupt", exit=True
+):
     """Cleanly shutdown the bot"""
 
     # Put all on-duty officers off duty - don't worry,

--- a/main.py
+++ b/main.py
@@ -112,7 +112,9 @@ async def on_ready():
 
     # Make sure this function does not create the officer manager twice
     if bot.sql is not None:
-        await clean_shutdown(bot, location="disconnection", person="automatic recovery", exit=False)
+        await clean_shutdown(
+            bot, location="disconnection", person="automatic recovery", exit=False
+        )
 
     # Create the function to run before officer removal
     async def before_officer_removal(bot, officer_id):
@@ -160,8 +162,8 @@ async def on_message(message):
         officer = bot.officer_manager.get_officer(message.author.id)
         await officer.process_loa(message)
 
-    if message.channel.id == bot.settings["request_rank_channel"]:
-        await analyze_promotion_request(bot, message)
+    # if message.channel.id == bot.settings["request_rank_channel"]:
+    #     await analyze_promotion_request(bot, message)
 
     # Archive the message
     if (

--- a/main.py
+++ b/main.py
@@ -69,9 +69,7 @@ else:
     settings = get_settings_file("settings")
     keys = get_settings_file("keys")
 
-bot = commands.Bot(
-    command_prefix=settings["bot_prefix"], intents=intents
-)  # 10/12/2020 - Destructo added intents
+bot = commands.Bot(command_prefix=settings["bot_prefix"], intents=intents)
 bot.settings = settings
 bot.officer_manager = None
 bot.sql = None

--- a/main.py
+++ b/main.py
@@ -222,7 +222,7 @@ async def on_voice_state_update(member, before, after):
 @bot.event
 async def on_member_update(before, after):
 
-    if bot.officer_manager is None:
+    if bot.officer_manager is None or before.bot or after.bot:
         return
 
     ############################

--- a/settings/Presets/local_settings.json
+++ b/settings/Presets/local_settings.json
@@ -1,6 +1,8 @@
 {
     "Server_ID": 566315650864381953,
-    "max_inactive_days": 28,
+    "max_inactive_days": 2,
+    "max_inactive_msg_days": 1,
+    "min_activity_minutes": 1,
     "bot_prefix": "=",
     "db_time_format": "%Y-%m-%d %H:%M:%S",
     "sleep_time_between_officer_checks": 60,

--- a/settings/Presets/remote_settings.json
+++ b/settings/Presets/remote_settings.json
@@ -1,6 +1,8 @@
 {
     "Server_ID": 645383380870889482,
-    "max_inactive_days": 28,
+    "max_inactive_days": 56,
+    "max_inactive_msg_days": 14,
+    "min_activity_minutes": 60,
     "bot_prefix": "=",
     "db_time_format": "%Y-%m-%d %H:%M:%S",
     "sleep_time_between_officer_checks": 3600,
@@ -22,7 +24,6 @@
     "leave_of_absence_channel": 725110720722894869,
     "request_rank_channel": 655570475216535585,
     "inactive_channel_name": "inactive",
-    "application_channel": 655793001787949086,
     "inactive_role": 765299198148476979,
     "training_finished_channel": 655570475216535585,
     "allowed_command_channels": [


### PR DESCRIPTION
I've adjusted the rules quite a bit on the inactive system as it was decided to change these in a discussion with Molls quite a bit ago.

This adds a few new things to the settings, I have added this to the local and remote settings files, but if you have a custom one you need to add the settings values "max_inactive_msg_days" and "min_activity_minutes"