### PR TITLE
Renewal time sql table fix

### DIFF
--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -233,15 +233,6 @@ class OfficerManager:
             member_name = f"{display_name} ({officer_id})"
 
         await self.bot.sql.request(
-            "DELETE FROM MessageActivityLog WHERE officer_id = %s", (officer_id)
-        )
-        await self.bot.sql.request(
-            "DELETE FROM TimeLog WHERE officer_id = %s", (officer_id)
-        )
-        await self.bot.sql.request(
-            "DELETE FROM LeaveTimes WHERE officer_id = %s", (officer_id)
-        )
-        await self.bot.sql.request(
             "DELETE FROM Officers WHERE officer_id = %s", (officer_id)
         )
 

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -309,9 +309,16 @@ class OfficerManager:
         renewed or join date as the value, witch ever one is higher.
         """
         data = await self.bot.sql.request(
-            "SELECT officer_id, renewed_time, started_monitoring_time FROM Officers"
+            """
+            SELECT
+                o.officer_id,
+                TIMESTAMP(GREATEST(o.started_monitoring_time, IFNULL(MAX(RT.renewed_time), '1970-1-1 0:0:0')))
+            FROM Officers o
+                LEFT JOIN RenewalTimes RT ON o.officer_id = RT.officer_id
+            GROUP BY o.officer_id
+            """
         )
-        return {d[0]: max(d[1], d[2]) for d in data}
+        return dict(data)
 
     def is_officer(self, member):
         """Returns true if specified member object has and of the LPD roles"""

--- a/SQL/database.sql
+++ b/SQL/database.sql
@@ -77,3 +77,16 @@ CREATE TABLE UserStrikes
     date DATETIME,
     entry_number INT PRIMARY KEY AUTO_INCREMENT
 );
+
+DROP TABLE IF EXISTS RenewalTimes;
+CREATE TABLE RenewalTimes
+(
+    renewal_id INT PRIMARY KEY AUTO_INCREMENT,
+    officer_id BIGINT UNSIGNED,
+    renewed_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    renewed_by BIGINT UNSIGNED,
+    reason TEXT,
+
+    CONSTRAINT officer_id_FK_RT FOREIGN KEY (officer_id) REFERENCES Officers(officer_id),
+    CONSTRAINT renewed_by_FK FOREIGN KEY (renewed_by) REFERENCES Officers(officer_id)
+);

--- a/SQL/database.sql
+++ b/SQL/database.sql
@@ -11,15 +11,15 @@ USE LPD_Officer_Monitor;
 
 CREATE TABLE Officers
 (
-	officer_id BIGINT UNSIGNED PRIMARY KEY,
+    officer_id BIGINT UNSIGNED PRIMARY KEY,
     started_monitoring_time DATETIME
 );
 
 CREATE TABLE Detainees
 (
-	member_id BIGINT UNSIGNED PRIMARY KEY,
+    member_id BIGINT UNSIGNED PRIMARY KEY,
     roles MEDIUMTEXT,
-	date DATETIME
+    date DATETIME
 );
 
 CREATE TABLE LeaveTimes
@@ -28,9 +28,9 @@ CREATE TABLE LeaveTimes
     date_start DATETIME,
     date_end DATETIME,
     reason TEXT,
-	request_id BIGINT UNSIGNED,
-	
-	CONSTRAINT officer_id_FK_LOA FOREIGN KEY (officer_id) REFERENCES Officers(officer_id)
+    request_id BIGINT UNSIGNED,
+
+    CONSTRAINT officer_id_FK_LOA FOREIGN KEY (officer_id) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 /*CREATE TABLE TimePeriods
@@ -41,32 +41,32 @@ CREATE TABLE LeaveTimes
 
 CREATE TABLE TimeLog
 (
-	entry_number INT PRIMARY KEY AUTO_INCREMENT,
-	officer_id BIGINT UNSIGNED,
+    entry_number INT PRIMARY KEY AUTO_INCREMENT,
+    officer_id BIGINT UNSIGNED,
     start_time TIMESTAMP,
     end_time TIMESTAMP,
     
-    CONSTRAINT officer_id_FK FOREIGN KEY (officer_id) REFERENCES Officers(officer_id)
+    CONSTRAINT officer_id_FK FOREIGN KEY (officer_id) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE MessageActivityLog
 (
-	entry_number INT PRIMARY KEY AUTO_INCREMENT,
+    entry_number INT PRIMARY KEY AUTO_INCREMENT,
     officer_id BIGINT UNSIGNED,
     channel_id BIGINT UNSIGNED,
-	message_id BIGINT UNSIGNED,
+    message_id BIGINT UNSIGNED,
     send_time TIMESTAMP,
     
-    CONSTRAINT officer_id_FK_2 FOREIGN KEY (officer_id) REFERENCES Officers(officer_id)
+    CONSTRAINT officer_id_FK_2 FOREIGN KEY (officer_id) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 DROP TABLE IF EXISTS VRChatNames;
 CREATE TABLE VRChatNames
 (
-	officer_id BIGINT UNSIGNED PRIMARY KEY,
+    officer_id BIGINT UNSIGNED PRIMARY KEY,
     vrc_name VARCHAR(255),
     
-    CONSTRAINT officer_id_FK_VRC_NAMES FOREIGN KEY (officer_id) REFERENCES Officers(officer_id)
+    CONSTRAINT officer_id_FK_VRC_NAMES FOREIGN KEY (officer_id) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 DROP TABLE IF EXISTS UserStrikes;
@@ -87,6 +87,6 @@ CREATE TABLE RenewalTimes
     renewed_by BIGINT UNSIGNED,
     reason TEXT,
 
-    CONSTRAINT officer_id_FK_RT FOREIGN KEY (officer_id) REFERENCES Officers(officer_id),
-    CONSTRAINT renewed_by_FK FOREIGN KEY (renewed_by) REFERENCES Officers(officer_id)
+    CONSTRAINT officer_id_FK_RT FOREIGN KEY (officer_id) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT renewed_by_FK FOREIGN KEY (renewed_by) REFERENCES Officers(officer_id) ON DELETE CASCADE ON UPDATE CASCADE
 );


### PR DESCRIPTION
This fixes the OfficerManager.get_officer_renew_dates function to use renewal time in a seperate table and also adds the table used into the database.sql file. This is the SQL table used:
```mysql
CREATE TABLE RenewalTimes
(
    renewal_id INT PRIMARY KEY AUTO_INCREMENT,
    officer_id BIGINT UNSIGNED,
    renewed_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    renewed_by BIGINT UNSIGNED,
    reason TEXT,

    CONSTRAINT officer_id_FK_RT FOREIGN KEY (officer_id) REFERENCES Officers(officer_id),
    CONSTRAINT renewed_by_FK FOREIGN KEY (renewed_by) REFERENCES Officers(officer_id)
);
```