### PR TITLE
Inactive system fix

### DIFF
--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -7,6 +7,7 @@ import asyncio
 import math
 import time
 from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
 
 # Community
 from discord import Member, Role
@@ -487,6 +488,25 @@ class Officer:
         if result == None:
             return None
         max_result = max(result, key=lambda x: time.mktime(x[3].timetuple()))
+        return self._create_activity_dict(max_result)
+
+    async def get_last_chat_activity(
+        self, counted_channel_ids
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Returns the date of an officer's last message, along with some other
+        data like the message id and channel id or None if the officer doesn't
+        have any messages in the bot.
+        """
+        result = await self._get_all_activity(counted_channel_ids)
+
+        if result == None:
+            return None
+
+        message_results = [r for r in result if r[2] is not None]
+        if len(message_results) == 0:
+            return None
+        max_result = max(message_results, key=lambda x: time.mktime(x[3].timetuple()))
         return self._create_activity_dict(max_result)
 
     async def get_all_activity(self, counted_channel_ids):

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -271,21 +271,27 @@ class OfficerManager:
         officers and how active they have been over a specific amount of time.
         """
 
-        db_request = (
-            """
-            SELECT O.officer_id, SUM(TIMESTAMPDIFF(SECOND, TL.start_time, TL.end_time)) AS "patrol_length"
-            FROM Officers O
-                LEFT JOIN TimeLog TL
-                    ON O.officer_id = TL.officer_id
-            WHERE
-                (TL.end_time > %s AND TL.end_time < %s)
-            """
-            + ("OR TL.end_time IS NULL\n" if include_no_activity else "")
-            + """
-            GROUP BY O.officer_id
+        db_request = """
+            SELECT TL.officer_id, SUM(TIMESTAMPDIFF(SECOND, TL.start_time, TL.end_time)) AS "patrol_length"
+            FROM TimeLog TL
+            WHERE TL.end_time > %s AND TL.end_time < %s
+            GROUP BY TL.officer_id
             ORDER BY patrol_length DESC
             """
-        )
+        if include_no_activity:
+            db_request = (
+                """
+                SELECT O.officer_id, IFNULL(A.patrol_length, 0) AS "patrol_length"
+                FROM Officers O
+                    LEFT JOIN (
+                        """
+                + db_request
+                + """
+                    ) A
+                        ON O.officer_id = A.officer_id
+                """
+            )
+
         arg_list: List[Any] = [from_datetime, to_datetime]
 
         if limit:

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -846,7 +846,7 @@ class Inactivity(commands.Cog):
             await ctx.send("No one was skipped because of chat activity.")
         else:
             skipped_str = (
-                "The following were skipped because of recent chat activity, on duty activity or being new:\n"
+                "The following were skipped because of recent chat activity:\n"
                 + "\n".join(m.mention for m in skipped_officers)
             )
             await send_long(ctx.channel, skipped_str, mention=False)
@@ -872,9 +872,9 @@ class Inactivity(commands.Cog):
         ).prompt(ctx)
         if confirm:
             # Add the inactive roles
-            await ctx.send("Please give me a moment to add the roles.")
+            await ctx.send("Please give me a moment to add the roles...")
             await self._mark_inactive(inactive_officers)
-            await ctx.send(f"All officers above have been marked as inactive.")
+            await ctx.send(f"**All officers above have been marked as inactive.**")
 
             # Notify about who was skipped because of chat activity
             await self._show_skipped_officers(ctx, chat_activity_skipped)

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -901,8 +901,7 @@ class Inactivity(commands.Cog):
         * Not be a white shirt (they're handled in a different way)
         * Not be skipped because of chat activity (explained below)
 
-        To be skipped because of chat activity you can fill either of the requirements below:
-        * Have a message in a monitored channel in the last "max_inactive_msg_days" days.
+        To be skipped because of chat activity you must have a message in a monitored channel in the last "max_inactive_msg_days" days.
 
         Being skipped because of chat activity means that that person will not be marked as inactive
         automatically, however, will go onto a list that is displayed after this command completes.

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -903,7 +903,6 @@ class Inactivity(commands.Cog):
 
         To be skipped because of chat activity you can fill either of the requirements below:
         * Have a message in a monitored channel in the last "max_inactive_msg_days" days.
-        * Have gone on duty in that time
 
         Being skipped because of chat activity means that that person will not be marked as inactive
         automatically, however, will go onto a list that is displayed after this command completes.


### PR DESCRIPTION
This adjusts the inactive system again with some slight modifications, the review list should be shorter as it doesn't contain as much of what it shouldn't really contain in the first place and it's shown before the process is started to help staff with measuring inactivity without doing an inactivity sweep.

This also fixes some bugs which were that:
- a lot of inactive people weren't included that should have been included because of a badly formed SQL query in get_most_active_officers
- Some people weren't being marked as chat active because of incorrect access to the counted channels list, this is also fixed.