### PR TITLE
Added purge command

### DIFF
--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -74,14 +74,7 @@ class Officer:
         self.squad = None
 
     async def remove(self, reason=None):
-
-        # Check to see if the member still has LPD roles, if so remove them
-        roles_to_remove = self.bot.officer_manager.all_lpd_ranks + self.bot.officer_manager.all_lpd_roles
         
-        for role in self.member.roles:
-            if role in roles_to_remove:
-                await self.member.remove_roles(role)
-                
         display_name = self.member.display_name
         await self.bot.officer_manager.remove_officer(
             self.id, reason=reason, display_name=display_name

--- a/Classes/Officer.py
+++ b/Classes/Officer.py
@@ -75,7 +75,13 @@ class Officer:
 
     async def remove(self, reason=None):
 
-        # Remove itself
+        # Check to see if the member still has LPD roles, if so remove them
+        roles_to_remove = self.bot.officer_manager.all_lpd_ranks + self.bot.officer_manager.all_lpd_roles
+        
+        for role in self.member.roles:
+            if role in roles_to_remove:
+                await self.member.remove_roles(role)
+                
         display_name = self.member.display_name
         await self.bot.officer_manager.remove_officer(
             self.id, reason=reason, display_name=display_name

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -27,6 +27,7 @@ class OfficerManager:
         self.bot = bot
         self._before_officer_removal = run_before_officer_removal
         self.all_officer_ids = all_officer_ids
+        self.officers_we_just_removed = []
 
         # Get the guild
         self.guild = bot.get_guild(bot.settings["Server_ID"])
@@ -155,7 +156,7 @@ class OfficerManager:
             # Build a list of all LPD roles besides ranks, for general availability
             all_lpd_role_ids = []
             for key, value in self.bot.settings.items():
-                if 'role' in key and 'detention' not in key and 'lpd_role' not in key and isinstance(value, int):
+                if 'role' in key and 'detention' not in key and isinstance(value, int):
                     all_lpd_role_ids.append(value)
                     
             self.all_lpd_roles = [
@@ -244,6 +245,7 @@ class OfficerManager:
         
         member = self.guild.get_member(officer_id)
         if member:
+            self.officers_we_just_removed.append(member.id)
             roles_to_remove = self.all_lpd_ranks + self.all_lpd_roles
             
             for role in member.roles:
@@ -345,6 +347,9 @@ class OfficerManager:
         """Returns true if specified member object has and of the LPD roles"""
 
         if member is None:
+            return False
+        if member.id in self.officers_we_just_removed:
+            self.officers_we_just_removed.remove(member.id)
             return False
         all_lpd_ranks = [x["id"] for x in self.bot.settings["role_ladder"]]
         all_lpd_ranks.append(self.bot.settings["lpd_role"])

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -155,8 +155,8 @@ class OfficerManager:
             # Build a list of all LPD roles besides ranks, for general availability
             all_lpd_role_ids = []
             for key, value in self.bot.settings.items():
-                if 'role' in key and 'detention' not in key:
-                    all_lpd_role_ids.append(int(value))
+                if 'role' in key and 'detention' not in key and isinstance(value, int):
+                    all_lpd_role_ids.append(value)
                     
             self.all_lpd_roles = [
                 self.guild.get_role(role_id)

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -155,7 +155,7 @@ class OfficerManager:
             # Build a list of all LPD roles besides ranks, for general availability
             all_lpd_role_ids = []
             for key, value in self.bot.settings.items():
-                if 'role' in key and 'detention' not in key and 'LPD_role' not in key and isinstance(value, int):
+                if 'role' in key and 'detention' not in key and 'lpd_role' not in key and isinstance(value, int):
                     all_lpd_role_ids.append(value)
                     
             self.all_lpd_roles = [

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -155,7 +155,7 @@ class OfficerManager:
             # Build a list of all LPD roles besides ranks, for general availability
             all_lpd_role_ids = []
             for key, value in self.bot.settings.items():
-                if 'role' in key and 'detention' not in key and isinstance(value, int):
+                if 'role' in key and 'detention' not in key and 'LPD_role' not in key and isinstance(value, int):
                     all_lpd_role_ids.append(value)
                     
             self.all_lpd_roles = [

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -241,6 +241,14 @@ class OfficerManager:
                 "Error encountered in before_officer_removal function",
                 traceback.format_exc(),
             )
+        
+        member = self.guild.get_member(officer_id)
+        if member:
+            roles_to_remove = self.all_lpd_ranks + self.all_lpd_roles
+            
+            for role in member.roles:
+                if role in roles_to_remove:
+                    await member.remove_roles(role)
 
         # Get display name for the Officer to be removed
         if display_name == None:

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -151,6 +151,17 @@ class OfficerManager:
                 self.guild.get_role(role_id)
                 for role_id in role_id_index(self.bot.settings)
             ]
+            
+            # Build a list of all LPD roles besides ranks, for general availability
+            all_lpd_role_ids = []
+            for key, value in self.bot.settings.items():
+                if 'role' in key and 'detention' not in key:
+                    all_lpd_role_ids.append(int(value))
+                    
+            self.all_lpd_roles = [
+                self.guild.get_role(role_id)
+                for role_id in all_lpd_role_ids
+            ]
 
         except Exception as error:
             print(error)

--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -251,6 +251,7 @@ class OfficerManager:
             for role in member.roles:
                 if role in roles_to_remove:
                     await member.remove_roles(role)
+            self.officers_we_just_removed.remove(member.id)
 
         # Get display name for the Officer to be removed
         if display_name == None:
@@ -349,7 +350,6 @@ class OfficerManager:
         if member is None:
             return False
         if member.id in self.officers_we_just_removed:
-            self.officers_we_just_removed.remove(member.id)
             return False
         all_lpd_ranks = [x["id"] for x in self.bot.settings["role_ladder"]]
         all_lpd_ranks.append(self.bot.settings["lpd_role"])

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -1009,14 +1009,16 @@ class Inactivity(commands.Cog):
             await ctx.send("Canceled purge")
             return
         
-        officers_removed = False
+        officers_removed = []
         for officer in self.bot.officer_manager.all_officers.values():
             if inactive_role in officer.member.roles:
+                officers_removed.append(officer)
+                
+                
+        if officers_removed != []:
+            for officer in officers_removed:
                 await officer.remove(reason='they were inactive')
                 await officer.member.remove_roles(inactive_role)
-                officers_removed = True
-                
-        if officers_removed:
             await ctx.send(f"All officers with the {inactive_role.name} role were removed from the LPD")
         else:
             await ctx.send(f"Could not find any officers with the {inactive_role.name} role")

--- a/Classes/commands.py
+++ b/Classes/commands.py
@@ -994,7 +994,33 @@ class Inactivity(commands.Cog):
                     ctx.author.id, "Renewed by direct discord command"
                 )
         await ctx.send("Renewed time for mentioned officers.")
-
+    
+    @checks.is_admin_bot_channel()
+    @checks.is_white_shirt()
+    @commands.command()
+    async def purge_inactive(self, ctx):
+        """Remove all LPD_inactive Officers from the LPD"""
+        inactive_role = self.bot.officer_manager.guild.get_role(
+            self.bot.settings["inactive_role"]
+        )
+        
+        confirm = await Confirm(f"Do you want to remove all officers with the {inactive_role.name} role?").prompt(ctx)
+        if not confirm:
+            await ctx.send("Canceled purge")
+            return
+        
+        officers_removed = False
+        for officer in self.bot.officer_manager.all_officers.values():
+            if inactive_role in officer.member.roles:
+                await officer.remove(reason='they were inactive')
+                await officer.member.remove_roles(inactive_role)
+                officers_removed = True
+                
+        if officers_removed:
+            await ctx.send(f"All officers with the {inactive_role.name} role were removed from the LPD")
+        else:
+            await ctx.send(f"Could not find any officers with the {inactive_role.name} role")
+            
     @checks.is_admin_bot_channel()
     @checks.is_white_shirt()
     @commands.command()


### PR DESCRIPTION
This is a priority addition requested by Molls.

- Adds `=purge_inactive` command, which asks if you would like to remove all inactive officers, then does so.
- Added automatic role removal in `OfficerManager.remove_officer`. All LPD ranks and roles will be removed.
- Altered `OfficerManager.is_officer() ` to prevent attempted double-removal of an officer when the LPD role is removed by the bot