### PR TITLE
Destructo loa patch

### DIFF
--- a/Classes/OfficerManager.py
+++ b/Classes/OfficerManager.py
@@ -395,3 +395,25 @@ class OfficerManager:
                 loa_entries = tuple(templist)
 
         return loa_entries
+
+    async def update_loa(self, request_id, channel_id):
+        """
+        Update the specified Leave of Absence
+        """
+
+        # Remove the old stored entry
+        await self.remove_loa(request_id)
+
+        # Get the message fresh from the channel
+        loa_channel = self.bot.get_channel(channel_id)
+        message = await loa_channel.fetch_message(request_id)
+
+        # Get the Officer that sent the message
+        officer_id = message.author.id
+        officer = self.get_officer(officer_id)
+
+        # This shouldn't ever happen, but just in case
+        if not officer: return
+
+        # Process the message as a new LOA
+        await officer.process_loa(message)

--- a/main.py
+++ b/main.py
@@ -293,6 +293,12 @@ async def on_raw_bulk_message_delete(payload):
 
 
 @bot.event
+async def on_raw_message_edit(payload):
+    if payload.channel_id == bot.settings["leave_of_absence_channel"]:
+        await bot.officer_manager.update_loa(payload.message_id, payload.channel_id)
+
+
+@bot.event
 async def on_raw_reaction_add(payload):
 
     if not bot.everything_ready:

--- a/settings/Presets/local_settings.json
+++ b/settings/Presets/local_settings.json
@@ -9,9 +9,9 @@
     "name_separator": ";",
     // Discord Activity
     "activity": {
-        "name": "Monitoring Officers",
+        "name": "Detroit: Become Human",
         "type": "streaming",
-        "url": "https://www.youtube.com/watch?v=oHg5SJYRHA0"
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     },
     // Channels
     "monitored_channels": {


### PR DESCRIPTION
Fixes the issue where users could edit an LOA message, but the bot wouldn't recognize the change.

New behavior treats a message edit as a new message.