### PR TITLE
Added new mode option to change output of rtv command.

### DIFF
--- a/src/layers/ui/discord_commands/other.py
+++ b/src/layers/ui/discord_commands/other.py
@@ -242,14 +242,15 @@ class Other(commands.Cog):
             await interaction_reply(di, f"`{role.name}` role has no members")
             return
         member_names = sorted(results, key=lambda m: m.display_name.lower())
-        if mode == RtvMode.all:
-            member_str = "\n".join(
-                f"{member.name} ({member.id})" for member in member_names
-            )
-        elif mode == RtvMode.discord_id:
-            member_str = "\n".join(str(member.id) for member in member_names)
-        else:
-            member_str = "\n".join(member.name for member in member_names)
+        match mode:
+            case RtvMode.all:
+                member_str = "\n".join(
+                    f"{member.name} ({member.id})" for member in member_names
+                )
+            case RtvMode.discord_id:
+                member_str = "\n".join(str(member.id) for member in member_names)
+            case _:
+                member_str = "\n".join(member.name for member in member_names)
         await interaction_reply(
             di, f"Here are the {len(member_names)} people with `{role.name}`'s role"
         )

--- a/src/layers/ui/discord_commands/other.py
+++ b/src/layers/ui/discord_commands/other.py
@@ -30,10 +30,12 @@ from src.layers.business.extra_functions import (
 
 log = logging.getLogger("lpd-officer-monitor")
 
+
 class RtvMode(enum.Enum):
     discord_name = 0
     discord_id = 1
     all = 2
+
 
 class Other(commands.Cog):
     def __init__(self, bot):
@@ -225,8 +227,15 @@ class Other(commands.Cog):
     @app_commands.guilds(discord.Object(id=settings.SERVER_ID))
     @app_commands.default_permissions(administrator=True)
     @app_commands.describe(role="list the members of this role")
-    @app_commands.describe(mode="output mode(default: discord_name) discord_name will return the display name on the server, discord_id will return the id of the user, all will return both")
-    async def rtv_slash(self, di: discord.Interaction, role: discord.Role, mode: RtvMode = RtvMode.discord_name):
+    @app_commands.describe(
+        mode="output mode(default: discord_name) discord_name will return the display name on the server, discord_id will return the id of the user, all will return both"
+    )
+    async def rtv_slash(
+        self,
+        di: discord.Interaction,
+        role: discord.Role,
+        mode: RtvMode = RtvMode.discord_name,
+    ):
         try:
             results = self.get_role_members(role)
         except errors.GetRoleMembersError:
@@ -234,7 +243,9 @@ class Other(commands.Cog):
             return
         member_names = sorted(results, key=lambda m: m.display_name.lower())
         if mode == RtvMode.all:
-            member_str = "\n".join(f"{member.name} ({member.id})" for member in member_names)
+            member_str = "\n".join(
+                f"{member.name} ({member.id})" for member in member_names
+            )
         elif mode == RtvMode.discord_id:
             member_str = "\n".join(str(member.id) for member in member_names)
         else:

--- a/src/layers/ui/discord_commands/other.py
+++ b/src/layers/ui/discord_commands/other.py
@@ -1,4 +1,5 @@
 # Settings import
+import enum
 import settings
 
 # Standard
@@ -29,6 +30,10 @@ from src.layers.business.extra_functions import (
 
 log = logging.getLogger("lpd-officer-monitor")
 
+class RtvMode(enum.Enum):
+    discord_name = 0
+    discord_id = 1
+    all = 2
 
 class Other(commands.Cog):
     def __init__(self, bot):
@@ -220,14 +225,20 @@ class Other(commands.Cog):
     @app_commands.guilds(discord.Object(id=settings.SERVER_ID))
     @app_commands.default_permissions(administrator=True)
     @app_commands.describe(role="list the members of this role")
-    async def rtv_slash(self, di: discord.Interaction, role: discord.Role):
+    @app_commands.describe(mode="output mode(default: discord_name) discord_name will return the display name on the server, discord_id will return the id of the user, all will return both")
+    async def rtv_slash(self, di: discord.Interaction, role: discord.Role, mode: RtvMode = RtvMode.discord_name):
         try:
             results = self.get_role_members(role)
         except errors.GetRoleMembersError:
             await interaction_reply(di, f"`{role.name}` role has no members")
             return
         member_names = sorted(results, key=lambda m: m.display_name.lower())
-        member_str = "\n".join(member.name for member in member_names)
+        if mode == RtvMode.all:
+            member_str = "\n".join(f"{member.name} ({member.id})" for member in member_names)
+        elif mode == RtvMode.discord_id:
+            member_str = "\n".join(str(member.id) for member in member_names)
+        else:
+            member_str = "\n".join(member.name for member in member_names)
         await interaction_reply(
             di, f"Here are the {len(member_names)} people with `{role.name}`'s role"
         )


### PR DESCRIPTION
## Changelog

### Added
- Added a `mode` option to the `/rtv` command.
- Added `RtvMode` choices:
  - `discord_name`  **( default )** shows Discord Usernames only. - **( default )**
  - `discord_id` shows Discord IDs only.
  - `all` shows member names with Discord IDs.

### Changed
- `/rtv` now changes role member output based on the selected mode.